### PR TITLE
fix: Codeowner file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @chibie @OnahProsperity will be requested for
+# review when someone opens a pull request.
+*       @chibie @OnahProsperity


### PR DESCRIPTION
By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


### Description

> This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns default owners for the repository and specifies that these owners will be requested for review when a pull request is opened.

* Assigned default owners for the repository: `@chibie`, `@OnahProsperity`


### References

 `.github/CODEOWNERS` 


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`